### PR TITLE
feat: Use .NET Standard version of TPL Dataflow

### DIFF
--- a/ReplaysService/ReplaysService.csproj
+++ b/ReplaysService/ReplaysService.csproj
@@ -51,14 +51,14 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer">
       <Version>2.4.1</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Tpl.Dataflow">
-      <Version>4.5.24</Version>
-    </PackageReference>
     <PackageReference Include="Ninject">
       <Version>3.3.4</Version>
     </PackageReference>
     <PackageReference Include="Ninject.Extensions.NamedScope">
       <Version>3.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Threading.Tasks.Dataflow">
+      <Version>4.8.0</Version>
     </PackageReference>
     <PackageReference Include="toofz.ActivityTracing">
       <Version>1.1.1</Version>


### PR DESCRIPTION
This is part of a series of changes to port toofz Replays Service to .NET Core.